### PR TITLE
Determine snapshot version from snapshotversion value directly

### DIFF
--- a/maven/resolver.py
+++ b/maven/resolver.py
@@ -20,9 +20,8 @@ class Resolver(object):
         path = "/%s/maven-metadata.xml" % (artifact.path())
 
         xml = self.requestor.request(self.base + path, self._onFail, lambda r: etree.parse(r))
-        timestamp = xml.xpath("/metadata/versioning/snapshot/timestamp/text()")[0]
-        buildNumber = xml.xpath("/metadata/versioning/snapshot/buildNumber/text()")[0]
-        return timestamp + "-" + buildNumber
+        snapshot_version = xml.xpath("/metadata/versioning/snapshotVersions/snapshotVersion/value/text()")[0]
+        return snapshot_version
 
     def _onFail(self, url, e):
         raise RequestException("Failed to download maven-metadata.xml from '%s'" % url)


### PR DESCRIPTION
I checked it with Apache repository and it works fine.

My test code
```
from maven.artifact import Artifact
from maven.downloader import Downloader

a = Artifact('org.apache.accumulo', 'accumulo-core', '2.0.0-SNAPSHOT')
Downloader(base='https://repository.apache.org/content/repositories/snapshots/').download(a)
```

[XSD for maven-meta.xml](
http://maven.apache.org/ref/3.0/maven-repository-metadata/repository-metadata.html#class_snapshotVersion) also mentions about snapshotVersion element.

Example maven-meta.xml
```
<?xml version="1.0" encoding="UTF-8"?>
<metadata modelVersion="1.1.0">
   <groupId>org.apache.accumulo</groupId>
   <artifactId>accumulo-core</artifactId>
   <version>1.7.3-SNAPSHOT</version>
   <versioning>
      <snapshot>
         <timestamp>20170117.231923</timestamp>
         <buildNumber>53</buildNumber>
      </snapshot>
      <lastUpdated>20170117231923</lastUpdated>
      <snapshotVersions>
         <snapshotVersion>
            <extension>jar</extension>
            <value>1.7.3-20170117.231923-53</value>
            <updated>20170117231923</updated>
         </snapshotVersion>
         <snapshotVersion>
            <extension>pom</extension>
            <value>1.7.3-20170117.231923-53</value>
            <updated>20170117231923</updated>
         </snapshotVersion>
         <snapshotVersion>
            <classifier>sources</classifier>
            <extension>jar</extension>
            <value>1.7.3-20170117.231923-53</value>
            <updated>20170117231923</updated>
         </snapshotVersion>
         <snapshotVersion>
            <classifier>javadoc</classifier>
            <extension>jar</extension>
            <value>1.7.3-20170117.231923-53</value>
            <updated>20170117231923</updated>
         </snapshotVersion>
      </snapshotVersions>
   </versioning>
</metadata>
```

So I think my code should work with maven central.