### PR TITLE
feat: Add formatting/linting checks (black and flake8)

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,20 @@
+name: Linting (black and flake8)
+
+on: [push, pull_request]
+
+jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:          
+          python-version: 3.9
+      - name: Install pip package(s)
+        run: pip install hatch
+      - name: Run black formatter check
+        run: hatch run lint:black --check --verbose src tests
+      - name: Run flake8 linter
+        run: hatch run lint:flake8

--- a/.github/workflows/pypi-build-n-publish.yml
+++ b/.github/workflows/pypi-build-n-publish.yml
@@ -1,18 +1,20 @@
 name: Build and publish to PyPI
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
     tags:
       - 'v*.*.*'
 
 jobs:
   build-and-publish:
+    needs: linting
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing      
     steps:
-    - uses: actions/checkout@v3
+    - name: Check out source repository
+      uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
       with:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # maven-artifact
 A python library to download and resolve maven artifacts.
+
+# Installation and Usage
+
+ * Install using pip: `pip install maven-artifact'
+ * Usage: run `maven-artifact` 
+
+# Requirements
+
+ * See `pyproject.toml` for details on required Python versions, pip packages etc.
+
+# Contributing
+
+ * Fork repo
+ * Before submitting a PR
+   * Perform formatting (black):  `hatch run:lint black src tests`
+   * Run linter (flake8): `hatch run:flake8`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,5 +81,4 @@ target-version = ['py310']
 [tool.flake8]
 ignore = ["W503" ]
 max-line-length = 120
-# exclude = tests/*
 max-complexity = 16

--- a/src/maven_artifact/__init__.py
+++ b/src/maven_artifact/__init__.py
@@ -1,4 +1,4 @@
-from .requestor import Requestor,RequestException
-from .artifact import Artifact
-from .resolver import Resolver
-from .downloader import Downloader
+from .requestor import Requestor, RequestException  # noqa: F401
+from .artifact import Artifact  # noqa: F401
+from .resolver import Resolver  # noqa: F401
+from .downloader import Downloader  # noqa: F401

--- a/src/maven_artifact/artifact.py
+++ b/src/maven_artifact/artifact.py
@@ -1,5 +1,6 @@
 import os
 
+
 class Artifact(object):
     def __init__(self, group_id, artifact_id, version, classifier=None, extension=None):
         if not group_id:
@@ -31,12 +32,7 @@ class Artifact(object):
         return f"{ret}.{self.extension}"
 
     def with_version(self, _version):
-        return Artifact(
-            self.group_id,
-            self.artifact_id,
-            _version,
-            self.classifier,
-            self.extension)
+        return Artifact(self.group_id, self.artifact_id, _version, self.classifier, self.extension)
 
     def _generate_filename(self):
         if not self.classifier:

--- a/src/maven_artifact/downloader.py
+++ b/src/maven_artifact/downloader.py
@@ -1,10 +1,11 @@
 import hashlib
 import os
-from .requestor import Requestor,RequestException
+from .requestor import Requestor, RequestException
 from .resolver import Resolver
 from .artifact import Artifact
 import sys
 import getopt
+
 
 class Downloader(object):
     def __init__(self, base="http://repo1.maven.org/maven2", username=None, password=None):
@@ -21,7 +22,7 @@ class Downloader(object):
         print(f"Downloading artifact {artifact} from {url}")
         onError = lambda uri, err: self._throwDownloadFailed(f"Failed to download {artifact} from {uri} \n{err}")
         with self.requestor.request(url, onError, stream=True) as r:
-            with open(filename, 'wb') as f:
+            with open(filename, "wb") as f:
                 for chunk in r.iter_content(chunk_size=8192):
                     f.write(chunk)
         print(f"Maven artifact {artifact} is downloaded to {filename}")
@@ -59,14 +60,13 @@ __doc__ = """
      %(program_name)s "org.apache.solr:solr:war:3.5.0"
   """
 
+
 def main():
     try:
-        opts, args = getopt.getopt(sys.argv[1:],
-            "m:u:p:ht",
-            ["maven-repo=", "username=", "password=", "hash-type="])
+        opts, args = getopt.getopt(sys.argv[1:], "m:u:p:ht", ["maven-repo=", "username=", "password=", "hash-type="])
     except getopt.GetoptError as err:
         # print help information and exit:
-        print(str(err)) # will print something like "option -a not recognized"
+        print(str(err))  # will print something like "option -a not recognized"
         usage()
         sys.exit(2)
 
@@ -100,7 +100,8 @@ def main():
 
 
 def usage():
-    print(__doc__ % {'program_name': os.path.basename(sys.argv[0])})
+    print(__doc__ % {"program_name": os.path.basename(sys.argv[0])})
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/src/maven_artifact/downloader.py
+++ b/src/maven_artifact/downloader.py
@@ -20,7 +20,10 @@ class Downloader(object):
             return artifact
 
         print(f"Downloading artifact {artifact} from {url}")
-        onError = lambda uri, err: self._throwDownloadFailed(f"Failed to download {artifact} from {uri} \n{err}")
+
+        def onError(uri, err):
+            self._throwDownloadFailed(f"Failed to download {artifact} from {uri} \n{err}")
+
         with self.requestor.request(url, onError, stream=True) as r:
             with open(filename, "wb") as f:
                 for chunk in r.iter_content(chunk_size=8192):
@@ -33,7 +36,10 @@ class Downloader(object):
 
     def verify_file(self, file, url, hash_type: str = "md5"):
         url = f"{url}.{hash_type}"
-        onError = lambda uri, err: self._throwDownloadFailed("Failed to download hash file from " + uri)
+
+        def onError(uri, err):
+            self._throwDownloadFailed("Failed to download hash file from " + uri)
+
         remote_hash = self.requestor.request(url, onError, lambda r: r.text)
         local_hash = getattr(hashlib, hash_type)(open(file, "rb").read()).hexdigest()
         return remote_hash == local_hash

--- a/src/maven_artifact/requestor.py
+++ b/src/maven_artifact/requestor.py
@@ -8,13 +8,12 @@ class RequestException(Exception):
 
 
 class Requestor(object):
-
-    def __init__(self, username = None, password = None, user_agent = "Maven Artifact Downloader/1.0"):
+    def __init__(self, username=None, password=None, user_agent="Maven Artifact Downloader/1.0"):
         self.user_agent = user_agent
         self.username = username
         self.password = password
 
-    def request(self, url, onFail, onSuccess = None, method: str = "get", **kwargs):
+    def request(self, url, onFail, onSuccess=None, method: str = "get", **kwargs):
         headers = {"User-Agent": self.user_agent}
         if self.username and self.password:
             token = self.username + ":" + self.password

--- a/src/maven_artifact/resolver.py
+++ b/src/maven_artifact/resolver.py
@@ -2,6 +2,7 @@ from lxml import etree
 
 from .requestor import RequestException
 
+
 class Resolver(object):
     def __init__(self, base, requestor):
         self.requestor = requestor
@@ -18,9 +19,7 @@ class Resolver(object):
 
     def _find_latest_snapshot_version(self, artifact):
         path = "/%s/maven-metadata.xml" % (artifact.path())
-        xml = self.requestor.request(
-            self.base + path, self._onFail, lambda r: etree.fromstring(r.content)
-            )
+        xml = self.requestor.request(self.base + path, self._onFail, lambda r: etree.fromstring(r.content))
         timestamp = xml.xpath("/metadata/versioning/snapshot/timestamp/text()")[0]
         buildNumber = xml.xpath("/metadata/versioning/snapshot/buildNumber/text()")[0]
         meta_version = f"{timestamp}-{buildNumber}"


### PR DESCRIPTION
Closes: https://github.com/hamnis/maven-artifact/issues/14

* Added formatting (black) and linting (flake8) to GitHub actions (will fail the pipeline)

* See Contributing in README.md for details on how to run these commands locally.

* @hamnis  your code triggers flake8 with [E731](https://www.flake8rules.com/rules/E731.html) in two places (see below). I did not fix them as I don't know how you want to to (follow best practise or simply ignore, if so add end of line comment `# noqa: E731` as in `src/maven_artifact/__init__.py`) but they need to be handled for pipeline not to fail. 
  1. `./src/maven_artifact/downloader.py:23:9: E731 do not assign a lambda expression, use a def`
  1. `./src/maven_artifact/downloader.py:36:9: E731 do not assign a lambda expression, use a def`

I wanted to use `wearerequired/lint-action` as it shows info in commits and PRs but it does not seem to work with flake8-pyproject.toml plugin (my bug report [here](https://github.com/wearerequired/lint-action/discussions/647) which we want otherwise we need to have configuration in two places (I _really_ prefer SSOT).

```yaml
- name: Install Python dependencies
  run: pip install black flake8 flake8-pyproject
- name: Run linters
  uses: wearerequired/lint-action@v2
  with:
    black: true
    flake8: true
```
