### PR TITLE
fix: Remove base64 encoding of OAuth Bearer token

### DIFF
--- a/src/maven_artifact/requestor.py
+++ b/src/maven_artifact/requestor.py
@@ -25,7 +25,7 @@ class Requestor(object):
         elif Utils.is_base64(self.password):
             headers["Authorization"] = f"Basic {self.password}"
         elif self.token:
-            headers["Authorization"] = f"Bearer {base64.b64encode(self.token.encode()).decode()}"
+            headers["Authorization"] = f"Bearer {self.token}"
 
         try:
             response = getattr(requests, method)(url, headers=headers, **kwargs)


### PR DESCRIPTION
I have now been able to verify the previous implementation using GitLab and JFrog. It did not work.

The OAuth Bearer token can't be base64 encoded. There is some confusion about this as explain [here](https://georgearisty.dev/posts/oauth2-token-bearer-usage/).

I've removed the base64 encoding of OAuth Bearer token. If it turns out that there are some odd cases that actually require base64 encoding then we can add an option --enable-oauth-token-base64-encoding or similiar.

Relates #23 