### PR TITLE
fix: Handle execution from pip install and as script correctly

### DIFF
--- a/src/maven_artifact/main.py
+++ b/src/maven_artifact/main.py
@@ -1,18 +1,20 @@
 #!/bin/env python
 
-import argparse
+
 import os
 import sys
+
+if __package__ is None:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    from maven_artifact.utils import Utils
+
+    Utils.is_installed_package = False
+
+import argparse
 import textwrap
-from importlib.metadata import version
+
 from maven_artifact.artifact import Artifact
-
-try:
-    from maven_artifact.utils import Utils
-except ImportError:
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-    from maven_artifact.utils import Utils
-
+from maven_artifact.utils import Utils
 from maven_artifact.requestor import RequestException
 from maven_artifact.downloader import Downloader
 
@@ -57,13 +59,15 @@ class WrappedNewlineFormatter(DescriptionWrappedNewlineFormatter):
 
 
 class MainCommand:
+
     def _get_arguments(self):
         parser = argparse.ArgumentParser(formatter_class=WrappedNewlineFormatter, epilog=__epilog__)
+
         parser.add_argument(
             "-V",
             "--version",
             action="version",
-            version=version("maven-artifact"),
+            version=f"{Utils.get_version()}",
         )
 
         parser.add_argument(

--- a/src/maven_artifact/requestor.py
+++ b/src/maven_artifact/requestor.py
@@ -1,6 +1,5 @@
 import base64
 import requests
-from importlib.metadata import version
 
 from maven_artifact.utils import Utils
 
@@ -16,12 +15,12 @@ class Requestor(object):
         username=None,
         password=None,
         token=None,
-        user_agent=f"Maven Artifact Downloader/{version('maven-artifact')}",
+        user_agent=f"Maven Artifact Downloader/{Utils.get_version()}",
     ):
-        self.user_agent = user_agent
         self.username = username
         self.password = password
         self.token = token
+        self.user_agent = user_agent
 
     def request(self, url, onFail, onSuccess=None, method: str = "get", **kwargs):
         headers = {"User-Agent": self.user_agent}

--- a/src/maven_artifact/utils.py
+++ b/src/maven_artifact/utils.py
@@ -1,7 +1,10 @@
 import base64
+from importlib.metadata import version
 
 
 class Utils:
+    is_installed_package = True
+
     @staticmethod
     def is_base64(sb):
         try:
@@ -15,3 +18,7 @@ class Utils:
             return base64.b64encode(base64.b64decode(sb_bytes)) == sb_bytes
         except Exception:
             return False
+
+    @staticmethod
+    def get_version():
+        return f"{version('maven-artifact')}" if Utils.is_installed_package else "non-pip-package"


### PR DESCRIPTION
The previous solution using "ImportError" will work if maven artifact is installed as a pip package but execution directly as a script (since the import will work). Using `__package__` allows us to check how the initial execution was.